### PR TITLE
Fix Background play on mobile (Android)

### DIFF
--- a/backend/api.js
+++ b/backend/api.js
@@ -21,7 +21,7 @@ module.exports = (app) => {
   if (config.auth) {
     // expressJwt 中间件 
     // 验证指定 http 请求的 JsonWebTokens 的有效性, 如果有效就将 JsonWebTokens 的值设置到 req.user 里面, 然后路由到相应的 router
-    app.use('/api', expressJwt({ secret: config.jwtsecret, audience: audience, issuer: issuer, getToken, algorithms: ['HS256'], requestProperty: 'user' }).unless({ path: ['/api/auth/me', '/api/health'] }));
+    app.use('/api', expressJwt({ secret: config.jwtsecret, audience: audience, issuer: issuer, getToken, algorithms: ['HS256'], requestProperty: 'user' }).unless({ path: ['/api/auth/me', '/api/health', '/api/debug/playback'] }));
   }
 
   app.use('/api', routes);

--- a/backend/api.js
+++ b/backend/api.js
@@ -21,7 +21,7 @@ module.exports = (app) => {
   if (config.auth) {
     // expressJwt 中间件 
     // 验证指定 http 请求的 JsonWebTokens 的有效性, 如果有效就将 JsonWebTokens 的值设置到 req.user 里面, 然后路由到相应的 router
-    app.use('/api', expressJwt({ secret: config.jwtsecret, audience: audience, issuer: issuer, getToken, algorithms: ['HS256'], requestProperty: 'user' }).unless({ path: ['/api/auth/me', '/api/health', '/api/debug/playback'] }));
+    app.use('/api', expressJwt({ secret: config.jwtsecret, audience: audience, issuer: issuer, getToken, algorithms: ['HS256'], requestProperty: 'user' }).unless({ path: ['/api/auth/me', '/api/health'] }));
   }
 
   app.use('/api', routes);

--- a/backend/routes/debug.js
+++ b/backend/routes/debug.js
@@ -5,8 +5,15 @@ const router = express.Router();
 // Logs debug events from the frontend to the server console
 router.post('/playback',
   (req, res, next) => {
-    const { event, source, track, time, duration } = req.body;
-    console.log(`[DEBUG PLAYBACK] ${event} | track=${track} | time=${time} | duration=${duration} | source=${source}`);
+    const body = req.body || {};
+    const { event, source, track, time, duration } = body;
+    // Log standard fields as before
+    if (event && track !== undefined) {
+      console.log(`[DEBUG PLAYBACK] ${event} | track=${track} | time=${time} | duration=${duration} | source=${source}`);
+    } else {
+      // Log custom event payloads (onEnded_state, onEnded_after, etc.)
+      console.log(`[DEBUG PLAYBACK] ${JSON.stringify(body)}`);
+    }
     res.json({ ok: true });
   }
 );

--- a/backend/routes/debug.js
+++ b/backend/routes/debug.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router();
+
+// Debug endpoint for mobile background playback testing
+// Logs debug events from the frontend to the server console
+router.post('/playback',
+  (req, res, next) => {
+    const { event, source, track, time, duration } = req.body;
+    console.log(`[DEBUG PLAYBACK] ${event} | track=${track} | time=${time} | duration=${duration} | source=${source}`);
+    res.json({ ok: true });
+  }
+);
+
+module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -21,5 +21,6 @@ router.use('/review', require('./review'));
 router.use('/histroy', require('./play_histroy'));
 // Other routes
 router.use('/', require('./metadata'));
+router.use('/debug', require('./debug'));
 
 module.exports = router;

--- a/backend/routes/media.js
+++ b/backend/routes/media.js
@@ -146,7 +146,6 @@ router.get('/check-lrc/:id/:index',
                   trackTitle + ext.toUpperCase(), // sometitle.mp3 -> sometitle.mp3.LRC
                 ];
                 for (const tryFileLoc of tryFileLocs) {
-                  console.log(`尝试查找歌词文件：${tryFileLoc}`);
                   if (fs.existsSync(path.join(fileDir, tryFileLoc))) {
                     foundLyricFileName = tryFileLoc;
                     break;

--- a/frontend/src/components/AudioElement.vue
+++ b/frontend/src/components/AudioElement.vue
@@ -321,6 +321,22 @@ export default {
       this._debugLog('onEnded')
       this._endedHandled = true;
       this._stopKeepalive()
+      // Log play mode and queue state to debug why next track doesn't start
+      try {
+        fetch('/api/debug/playback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            event: 'onEnded_state',
+            playMode: this.playMode.name,
+            queueIndex: this.queueIndex,
+            queueLen: this.queue.length,
+            isLast: this.queueIndex === this.queue.length - 1,
+            ts: Date.now()
+          }),
+          keepalive: true
+        }).catch(() => {})
+      } catch (e) {}
       switch (this.playMode.name) {
         case "all repeat":
           if (this.queueIndex === this.queue.length - 1) {
@@ -346,9 +362,23 @@ export default {
           if (this.queueIndex === this.queue.length - 1) {
             this.PAUSE()
           } else {
-            this.NEXT_TRACK()
-          }
+          this.NEXT_TRACK()
+        }
       }
+      // Log action taken
+      try {
+        fetch('/api/debug/playback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            event: 'onEnded_after',
+            queueIndex: this.queueIndex,
+            playing: this.playing,
+            ts: Date.now()
+          }),
+          keepalive: true
+        }).catch(() => {})
+      } catch (e) {}
     },
 
     _startKeepalive() {

--- a/frontend/src/components/AudioElement.vue
+++ b/frontend/src/components/AudioElement.vue
@@ -99,6 +99,7 @@ export default {
       isChangingCurrentTime: false,
       changeCurrentTime: 0,
       _endedHandled: false,
+      _keepaliveTimer: null,
     }
   },
 
@@ -162,6 +163,7 @@ export default {
         const media = this.plyr.media;
         media.load();
         this._endedHandled = false;
+        this._stopKeepalive()
         this.loadLrcFile();
         this.updateMediaSessionMetadata();
         // Explicitly start playback after loading new source.
@@ -231,11 +233,13 @@ export default {
 
     onPause() {
       this.playLrc(false)
+      this._stopKeepalive()
       this.PAUSE()
       try { navigator.mediaSession.playbackState = 'paused' } catch (e) {}
     },
     onPlaying() {
       this.playLrc(true)
+      this._startKeepalive()
       this.PLAY()
       try { navigator.mediaSession.playbackState = 'playing' } catch (e) {}
     },
@@ -304,6 +308,7 @@ export default {
 
     onEnded () {
       this._endedHandled = true;
+      this._stopKeepalive()
       switch (this.playMode.name) {
         case "all repeat":
           if (this.queueIndex === this.queue.length - 1) {
@@ -331,6 +336,31 @@ export default {
           } else {
             this.NEXT_TRACK()
           }
+      }
+    },
+
+    _startKeepalive() {
+      this._stopKeepalive()
+      // Recurring 30s timeout that keeps the JS event loop alive when
+      // the phone is locked. Without this, Chrome may batch native DOM
+      // events (like 'ended') and delay JS execution, causing the next
+      // track to not start playing promptly.
+      const tick = () => {
+        if (!this.playing || !this.plyr) return
+        // Retry play if the media loaded but autoplay was blocked
+        // (common when the page is hidden / phone is locked)
+        if (this.plyr.media && this.plyr.media.paused && this.plyr.duration > 0) {
+          this.plyr.play().catch(() => {})
+        }
+        this._keepaliveTimer = setTimeout(tick, 30000)
+      }
+      this._keepaliveTimer = setTimeout(tick, 30000)
+    },
+
+    _stopKeepalive() {
+      if (this._keepaliveTimer !== null) {
+        clearTimeout(this._keepaliveTimer)
+        this._keepaliveTimer = null
       }
     },
 
@@ -576,6 +606,7 @@ export default {
   },
 
   beforeUnmount() {
+    this._stopKeepalive()
     const container = this.$refs.plyrContainer;
     if (container) {
       const media = container.querySelector('video') || container.querySelector('audio');

--- a/frontend/src/components/AudioElement.vue
+++ b/frontend/src/components/AudioElement.vue
@@ -241,14 +241,12 @@ export default {
       this.playLrc(false)
       this._stopKeepalive()
       this.PAUSE()
-      try { navigator.mediaSession.playbackState = 'paused' } catch (e) {}
     },
     onPlaying() {
       this._debugLog('onPlaying')
       this.playLrc(true)
       this._startKeepalive()
       this.PLAY()
-      try { navigator.mediaSession.playbackState = 'playing' } catch (e) {}
     },
     onWaiting() {
       this.playLrc(false)
@@ -287,6 +285,7 @@ export default {
         this.$q.notify({message: "已恢复播放历史", timeout: 1000})
       }
     },
+
     onTimeupdate () {
       this.SET_CURRENT_TIME(this.plyr.currentTime)
       if (this.enablePIPLyrics) this.debouncedPlayLrc(false)
@@ -301,15 +300,6 @@ export default {
           this.CLEAR_SLEEP_MODE()
           this.$q.sessionStorage.set('sleepTime', null)
           this.$q.sessionStorage.set('sleepMode', false)
-        }
-      }
-      // Fallback ended detection: on some Android browsers the 'ended' event
-      // does not fire when the phone is locked. Use timeupdate to detect
-      // that we've reached the end of the track.
-      if (!this._endedHandled && this.plyr && this.plyr.duration > 0) {
-        if (this.plyr.currentTime >= this.plyr.duration - 0.5) {
-          this._endedHandled = true;
-          this.onEnded();
         }
       }
     },
@@ -577,7 +567,6 @@ export default {
           navigator.mediaSession.setActionHandler('previoustrack', null);
           navigator.mediaSession.setActionHandler('seekbackward', null);
           navigator.mediaSession.setActionHandler('seekforward', null);
-          navigator.mediaSession.playbackState = 'none';
         } else {
           navigator.mediaSession.metadata = new window.MediaMetadata({
             title: this.currentPlayingFile.title,
@@ -622,7 +611,6 @@ export default {
           navigator.mediaSession.setActionHandler('seekforward', () => {
             this.SET_FORWARD_SEEK_MODE(true)
           })
-          navigator.mediaSession.playbackState = this.playing ? 'playing' : 'paused';
         }
       } catch (e) {
         console.warn("set mediasession failed, because: ", e)

--- a/frontend/src/components/AudioElement.vue
+++ b/frontend/src/components/AudioElement.vue
@@ -162,14 +162,13 @@ export default {
       if (url) {
         const media = this.plyr.media;
         media.load();
+        this._debugLog('source_changed')
         this._endedHandled = false;
         this._stopKeepalive()
         this.loadLrcFile();
         this.updateMediaSessionMetadata();
-        // Explicitly start playback after loading new source.
-        // On Android when locked, 'canplay' may not fire (browser throttles
-        // media loading in hidden pages), so we cannot rely on onCanplay alone.
         if (this.playing) {
+          this._debugLog('source_play_attempt')
           this.plyr.play().catch(() => {})
         }
       }
@@ -232,12 +231,14 @@ export default {
     formatSeconds,
 
     onPause() {
+      this._debugLog('onPause')
       this.playLrc(false)
       this._stopKeepalive()
       this.PAUSE()
       try { navigator.mediaSession.playbackState = 'paused' } catch (e) {}
     },
     onPlaying() {
+      this._debugLog('onPlaying')
       this.playLrc(true)
       this._startKeepalive()
       this.PLAY()
@@ -267,6 +268,7 @@ export default {
     ]),
 
     onCanplay () {
+      this._debugLog('onCanplay')
       this.SET_DURATION(this.plyr.duration)
 
       if (this.playing && this.plyr.currentTime !== this.plyr.duration) {
@@ -307,6 +309,7 @@ export default {
     },
 
     onEnded () {
+      this._debugLog('onEnded')
       this._endedHandled = true;
       this._stopKeepalive()
       switch (this.playMode.name) {
@@ -341,15 +344,10 @@ export default {
 
     _startKeepalive() {
       this._stopKeepalive()
-      // Recurring 30s timeout that keeps the JS event loop alive when
-      // the phone is locked. Without this, Chrome may batch native DOM
-      // events (like 'ended') and delay JS execution, causing the next
-      // track to not start playing promptly.
       const tick = () => {
         if (!this.playing || !this.plyr) return
-        // Retry play if the media loaded but autoplay was blocked
-        // (common when the page is hidden / phone is locked)
         if (this.plyr.media && this.plyr.media.paused && this.plyr.duration > 0) {
+          this._debugLog('keepalive_retry_play')
           this.plyr.play().catch(() => {})
         }
         this._keepaliveTimer = setTimeout(tick, 30000)
@@ -362,6 +360,27 @@ export default {
         clearTimeout(this._keepaliveTimer)
         this._keepaliveTimer = null
       }
+    },
+
+    _debugLog(event) {
+      // Send debug event to server for analysis
+      // Uses fetch with keepalive so it survives page suspension
+      try {
+        fetch('/api/debug/playback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            event,
+            source: this.source ? this.source.slice(0, 80) : 'none',
+            track: this.queueIndex,
+            time: this.plyr ? this.plyr.currentTime?.toFixed(1) : -1,
+            duration: this.plyr ? this.plyr.duration?.toFixed(1) : -1,
+            playing: this.playing,
+            ts: Date.now()
+          }),
+          keepalive: true
+        }).catch(() => {})
+      } catch (e) {}
     },
 
     onSeeked() {

--- a/frontend/src/components/AudioElement.vue
+++ b/frontend/src/components/AudioElement.vue
@@ -99,7 +99,6 @@ export default {
 
       isChangingCurrentTime: false,
       changeCurrentTime: 0,
-      _keepaliveTimer: null,
     }
   },
 
@@ -238,13 +237,11 @@ export default {
     onPause() {
       this._debugLog('onPause')
       this.playLrc(false)
-      this._stopKeepalive()
       this.PAUSE()
     },
     onPlaying() {
       this._debugLog('onPlaying')
       this.playLrc(true)
-      this._startKeepalive()
       this.PLAY()
     },
     onWaiting() {
@@ -305,7 +302,6 @@ export default {
 
     onEnded () {
       this._debugLog('onEnded')
-      this._stopKeepalive()
       // Log play mode and queue state to debug why next track doesn't start
       try {
         fetch('/api/debug/playback', {
@@ -377,7 +373,6 @@ export default {
         if (newUrl) {
           this._debugLog('direct_load')
           this._onSourceChange(newUrl)
-          this._startKeepalive()
         }
       }
     },
@@ -405,10 +400,9 @@ export default {
     },
 
     // Shared body for reacting to a source change: load the new track,
-    // reset ended-detection, refresh lyrics/metadata, and start playback.
+    // refresh lyrics/metadata, and start playback.
     _onSourceChange (url) {
       if (!this._loadSource(url)) return
-      this._stopKeepalive()
       this.loadLrcFile();
       this.updateMediaSessionMetadata();
       if (this.playing) {
@@ -424,26 +418,6 @@ export default {
             }).catch(() => {})
           } catch (err) {}
         })
-      }
-    },
-
-    _startKeepalive() {
-      this._stopKeepalive()
-      const tick = () => {
-        if (!this.playing || !this.plyr) return
-        if (this.plyr.media && this.plyr.media.paused && this.plyr.duration > 0) {
-          this._debugLog('keepalive_retry_play')
-          this.plyr.play().catch(() => {})
-        }
-        this._keepaliveTimer = setTimeout(tick, 30000)
-      }
-      this._keepaliveTimer = setTimeout(tick, 30000)
-    },
-
-    _stopKeepalive() {
-      if (this._keepaliveTimer !== null) {
-        clearTimeout(this._keepaliveTimer)
-        this._keepaliveTimer = null
       }
     },
 
@@ -744,7 +718,6 @@ export default {
   },
 
   beforeUnmount() {
-    this._stopKeepalive()
     const container = this.$refs.plyrContainer;
     if (container) {
       const media = container.querySelector('video') || container.querySelector('audio');

--- a/frontend/src/components/AudioElement.vue
+++ b/frontend/src/components/AudioElement.vue
@@ -100,6 +100,7 @@ export default {
       changeCurrentTime: 0,
       _endedHandled: false,
       _keepaliveTimer: null,
+      _directLoadHash: null,
     }
   },
 
@@ -159,11 +160,34 @@ export default {
     },
 
     source (url, oldUrl) {
+      // Always log source watcher fires to debug why track doesn't advance
+      try {
+        fetch('/api/debug/playback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            event: 'source_watcher_fired',
+            oldUrl: (oldUrl||'').slice(0,60),
+            newUrl: (url||'').slice(0,60),
+            urlMatch: url === oldUrl,
+            ts: Date.now()
+          }),
+          keepalive: true
+        }).catch(() => {})
+      } catch (e) {}
       if (url && url !== oldUrl) {
         const media = this.plyr.media;
+        // If onEnded already loaded this track directly (page was frozen
+        // and the watcher was deferred), skip the reload to avoid
+        // resetting playback back to 0.
+        const currentHash = this.currentPlayingFile && this.currentPlayingFile.hash
+        if (this._directLoadHash && currentHash === this._directLoadHash) {
+          this._directLoadHash = null
+          this._debugLog('watcher_skip_direct_load')
+          return
+        }
         media.load();
         this._debugLog('source_changed')
-        // Log URL comparison to identify what's actually changing
         try {
           fetch('/api/debug/playback', {
             method: 'POST',
@@ -375,8 +399,9 @@ export default {
           this.NEXT_TRACK()
         }
       }
-      // Log action taken
+      // Log action taken and whether source computed property changed
       try {
+        const newHash = this.currentPlayingFile && this.currentPlayingFile.hash;
         fetch('/api/debug/playback', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -384,11 +409,36 @@ export default {
             event: 'onEnded_after',
             queueIndex: this.queueIndex,
             playing: this.playing,
+            newHash: newHash,
             ts: Date.now()
           }),
           keepalive: true
         }).catch(() => {})
       } catch (e) {}
+
+      // Directly load and play the next track synchronously.
+      // Chrome freezes hidden pages: Vue's nextTick-based `source` watcher
+      // may be deferred for minutes, so the watcher-driven media.load()
+      // happens far too late. Doing it here (inside the event handler)
+      // starts the next track immediately. The watcher will later fire
+      // with the same URL; the marker below makes it skip the reload.
+      if (this.playing && this.plyr && this.playMode.name !== "repeat once") {
+        const media = this.plyr.media
+        const newUrl = this.source
+        if (media && newUrl) {
+          this._directLoadHash = this.currentPlayingFile && this.currentPlayingFile.hash
+          media.src = newUrl
+          media.load()
+          this._endedHandled = false
+          this.loadLrcFile()
+          this.updateMediaSessionMetadata()
+          this._debugLog('direct_load')
+          media.play().catch(() => {
+            this._debugLog('direct_load_play_rejected')
+          })
+          this._startKeepalive()
+        }
+      }
     },
 
     _startKeepalive() {
@@ -483,6 +533,19 @@ export default {
         if (!this.playing) this.lrcObj.pause()
         this.SET_HAS_LYRIC(true);
       } catch(error) {
+        try {
+          fetch('/api/debug/playback', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              event: 'lyric_fetch_error',
+              message: error && error.message,
+              status: error && error.response && error.response.status,
+              ts: Date.now()
+            }),
+            keepalive: true
+          }).catch(() => {})
+        } catch (e) {}
         if (error.response) {
           if (error.response.status !== 401) {
             console.error(error);
@@ -623,6 +686,27 @@ export default {
       // Direct listener on the media element — browser fires 'ended' on the element
       // even when the page is hidden (phone locked). Bypasses any plyr event throttling.
       media.addEventListener('ended', this.onEnded);
+
+      // Log media element errors (MEDIA_ERR_NETWORK etc.) to debug endpoint
+      media.addEventListener('error', () => {
+        const err = media.error;
+        try {
+          fetch('/api/debug/playback', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              event: 'media_error',
+              code: err && err.code,
+              message: err && err.message,
+              src: (media.currentSrc || '').slice(0, 60),
+              networkState: media.networkState,
+              readyState: media.readyState,
+              ts: Date.now()
+            }),
+            keepalive: true
+          }).catch(() => {})
+        } catch (e) {}
+      });
     },
 
     initAudioAnalyzer () {

--- a/frontend/src/components/AudioElement.vue
+++ b/frontend/src/components/AudioElement.vue
@@ -158,11 +158,20 @@ export default {
       }
     },
 
-    source (url) {
-      if (url) {
+    source (url, oldUrl) {
+      if (url && url !== oldUrl) {
         const media = this.plyr.media;
         media.load();
         this._debugLog('source_changed')
+        // Log URL comparison to identify what's actually changing
+        try {
+          fetch('/api/debug/playback', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ event: 'source_url_diff', oldUrl: (oldUrl||'').slice(0,60), newUrl: (url||'').slice(0,60), ts: Date.now() }),
+            keepalive: true
+          }).catch(() => {})
+        } catch (e) {}
         this._endedHandled = false;
         this._stopKeepalive()
         this.loadLrcFile();

--- a/frontend/src/components/AudioElement.vue
+++ b/frontend/src/components/AudioElement.vue
@@ -178,7 +178,17 @@ export default {
         this.updateMediaSessionMetadata();
         if (this.playing) {
           this._debugLog('source_play_attempt')
-          this.plyr.play().catch(() => {})
+          this.plyr.play().catch((e) => {
+            this._debugLog('source_play_rejected')
+            try {
+              fetch('/api/debug/playback', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ event: 'source_play_error', error: String(e), name: e && e.name, ts: Date.now() }),
+                keepalive: true
+              }).catch(() => {})
+            } catch (err) {}
+          })
         }
       }
     },

--- a/frontend/src/components/AudioElement.vue
+++ b/frontend/src/components/AudioElement.vue
@@ -513,7 +513,7 @@ export default {
       const player = this.plyr;
 
       this.SET_VOLUME(player.volume);
-
+      
       player.on('canplay', () => this.onCanplay());
       player.on('timeupdate', () => this.onTimeupdate());
       player.on('ended', () => this.onEnded());
@@ -521,6 +521,10 @@ export default {
       player.on('playing', () => this.onPlaying());
       player.on('waiting', () => this.onWaiting());
       player.on('pause', () => this.onPause());
+
+      // Direct listener on the media element — browser fires 'ended' on the element
+      // even when the page is hidden (phone locked). Bypasses any plyr event throttling.
+      media.addEventListener('ended', this.onEnded);
     },
 
     initAudioAnalyzer () {
@@ -570,6 +574,16 @@ export default {
       this.loadLrcFile();
     }
   },
+
+  beforeUnmount() {
+    const container = this.$refs.plyrContainer;
+    if (container) {
+      const media = container.querySelector('video') || container.querySelector('audio');
+      if (media) {
+        media.removeEventListener('ended', this.onEnded);
+      }
+    }
+   },
 }
 </script>
 

--- a/frontend/src/components/AudioElement.vue
+++ b/frontend/src/components/AudioElement.vue
@@ -99,7 +99,6 @@ export default {
 
       isChangingCurrentTime: false,
       changeCurrentTime: 0,
-      _endedHandled: false,
       _keepaliveTimer: null,
     }
   },
@@ -306,7 +305,6 @@ export default {
 
     onEnded () {
       this._debugLog('onEnded')
-      this._endedHandled = true;
       this._stopKeepalive()
       // Log play mode and queue state to debug why next track doesn't start
       try {
@@ -410,7 +408,6 @@ export default {
     // reset ended-detection, refresh lyrics/metadata, and start playback.
     _onSourceChange (url) {
       if (!this._loadSource(url)) return
-      this._endedHandled = false;
       this._stopKeepalive()
       this.loadLrcFile();
       this.updateMediaSessionMetadata();
@@ -664,14 +661,15 @@ export default {
       
       player.on('canplay', () => this.onCanplay());
       player.on('timeupdate', () => this.onTimeupdate());
-      player.on('ended', () => this.onEnded());
       player.on('seeked', () => this.onSeeked());
       player.on('playing', () => this.onPlaying());
       player.on('waiting', () => this.onWaiting());
       player.on('pause', () => this.onPause());
 
-      // Direct listener on the media element — browser fires 'ended' on the element
-      // even when the page is hidden (phone locked). Bypasses any plyr event throttling.
+      // Single source of truth for 'ended': a direct listener on the media
+      // element. Plyr's container-level 'ended' event is proxied from this
+      // same native event, so it can never fire when this listener doesn't
+      // — and registering both makes onEnded run twice per track end.
       media.addEventListener('ended', this.onEnded);
 
       // Log media element errors (MEDIA_ERR_NETWORK etc.) to debug endpoint

--- a/frontend/src/components/AudioElement.vue
+++ b/frontend/src/components/AudioElement.vue
@@ -158,22 +158,7 @@ export default {
     },
 
     source (url, oldUrl) {
-      try {
-        fetch('/api/debug/playback', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            event: 'source_watcher_fired',
-            oldUrl: (oldUrl||'').slice(0,60),
-            newUrl: (url||'').slice(0,60),
-            urlMatch: url === oldUrl,
-            ts: Date.now()
-          }),
-          keepalive: true
-        }).catch(() => {})
-      } catch (e) {}
       if (url && url !== oldUrl) {
-        this._debugLog('source_changed')
         this._onSourceChange(url)
       }
     },
@@ -235,12 +220,10 @@ export default {
     formatSeconds,
 
     onPause() {
-      this._debugLog('onPause')
       this.playLrc(false)
       this.PAUSE()
     },
     onPlaying() {
-      this._debugLog('onPlaying')
       this.playLrc(true)
       this.PLAY()
     },
@@ -268,7 +251,6 @@ export default {
     ]),
 
     onCanplay () {
-      this._debugLog('onCanplay')
       this.SET_DURATION(this.plyr.duration)
 
       if (this.playing && this.plyr.currentTime !== this.plyr.duration) {
@@ -301,23 +283,6 @@ export default {
     },
 
     onEnded () {
-      this._debugLog('onEnded')
-      // Log play mode and queue state to debug why next track doesn't start
-      try {
-        fetch('/api/debug/playback', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            event: 'onEnded_state',
-            playMode: this.playMode.name,
-            queueIndex: this.queueIndex,
-            queueLen: this.queue.length,
-            isLast: this.queueIndex === this.queue.length - 1,
-            ts: Date.now()
-          }),
-          keepalive: true
-        }).catch(() => {})
-      } catch (e) {}
       switch (this.playMode.name) {
         case "all repeat":
           if (this.queueIndex === this.queue.length - 1) {
@@ -346,23 +311,6 @@ export default {
           this.NEXT_TRACK()
         }
       }
-      // Log action taken and whether source computed property changed
-      try {
-        const newHash = this.currentPlayingFile && this.currentPlayingFile.hash;
-        fetch('/api/debug/playback', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            event: 'onEnded_after',
-            queueIndex: this.queueIndex,
-            playing: this.playing,
-            newHash: newHash,
-            ts: Date.now()
-          }),
-          keepalive: true
-        }).catch(() => {})
-      } catch (e) {}
-
       // Load and play the next track synchronously, inside the event handler.
       // Chrome freezes hidden pages: Vue's nextTick-based `source` watcher
       // may be deferred for minutes, so the watcher-driven load happens far
@@ -371,7 +319,6 @@ export default {
       if (this.playing && this.plyr && this.playMode.name !== "repeat once") {
         const newUrl = this.source
         if (newUrl) {
-          this._debugLog('direct_load')
           this._onSourceChange(newUrl)
         }
       }
@@ -391,7 +338,6 @@ export default {
       }
       const absUrl = new URL(url, window.location.href).href
       if (media.currentSrc === absUrl && !media.error) {
-        this._debugLog('load_source_skip_same')
         return false
       }
       media.src = url
@@ -406,40 +352,8 @@ export default {
       this.loadLrcFile();
       this.updateMediaSessionMetadata();
       if (this.playing) {
-        this._debugLog('source_play_attempt')
-        this.plyr.play().catch((e) => {
-          this._debugLog('source_play_rejected')
-          try {
-            fetch('/api/debug/playback', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ event: 'source_play_error', error: String(e), name: e && e.name, ts: Date.now() }),
-              keepalive: true
-            }).catch(() => {})
-          } catch (err) {}
-        })
+        this.plyr.play().catch(() => {})
       }
-    },
-
-    _debugLog(event) {
-      // Send debug event to server for analysis
-      // Uses fetch with keepalive so it survives page suspension
-      try {
-        fetch('/api/debug/playback', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            event,
-            source: this.source ? this.source.slice(0, 80) : 'none',
-            track: this.queueIndex,
-            time: this.plyr ? this.plyr.currentTime?.toFixed(1) : -1,
-            duration: this.plyr ? this.plyr.duration?.toFixed(1) : -1,
-            playing: this.playing,
-            ts: Date.now()
-          }),
-          keepalive: true
-        }).catch(() => {})
-      } catch (e) {}
     },
 
     onSeeked() {
@@ -493,19 +407,6 @@ export default {
         if (!this.playing) this.lrcObj.pause()
         this.SET_HAS_LYRIC(true);
       } catch(error) {
-        try {
-          fetch('/api/debug/playback', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              event: 'lyric_fetch_error',
-              message: error && error.message,
-              status: error && error.response && error.response.status,
-              ts: Date.now()
-            }),
-            keepalive: true
-          }).catch(() => {})
-        } catch (e) {}
         if (error.response) {
           if (error.response.status !== 401) {
             console.error(error);
@@ -645,27 +546,6 @@ export default {
       // same native event, so it can never fire when this listener doesn't
       // — and registering both makes onEnded run twice per track end.
       media.addEventListener('ended', this.onEnded);
-
-      // Log media element errors (MEDIA_ERR_NETWORK etc.) to debug endpoint
-      media.addEventListener('error', () => {
-        const err = media.error;
-        try {
-          fetch('/api/debug/playback', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              event: 'media_error',
-              code: err && err.code,
-              message: err && err.message,
-              src: (media.currentSrc || '').slice(0, 60),
-              networkState: media.networkState,
-              readyState: media.readyState,
-              ts: Date.now()
-            }),
-            keepalive: true
-          }).catch(() => {})
-        } catch (e) {}
-      });
     },
 
     initAudioAnalyzer () {

--- a/frontend/src/components/AudioElement.vue
+++ b/frontend/src/components/AudioElement.vue
@@ -17,11 +17,12 @@
     反之，audio虽然可以播放video的音频，但是将其作为canvas的绘制源，因此倾向于使用video来播放所有媒体元素-->
     <!--注意，这里video设置了一个id，因为需要被其他组件通过document.querySelector方式进行查找引用-->
     <div ref="plyrContainer" style="display: none;">
+      <!-- media src is managed imperatively (see _loadSource): a <source :src>
+           binding only takes effect via media.load() and races with the
+           nextTick-deferred watcher when Chrome freezes the hidden page -->
       <video v-if="enableVideoSource" class="hide-in-global-page-for-pip" id="mediaVideo" crossorigin="anonymous" playsinline controls>
-        <source v-if="source" :src="source" />
       </video>
       <audio v-else crossorigin="anonymous">
-        <source v-if="source" :src="source" />
       </audio>
     </div>
   </div>
@@ -100,7 +101,6 @@ export default {
       changeCurrentTime: 0,
       _endedHandled: false,
       _keepaliveTimer: null,
-      _directLoadHash: null,
     }
   },
 
@@ -160,7 +160,6 @@ export default {
     },
 
     source (url, oldUrl) {
-      // Always log source watcher fires to debug why track doesn't advance
       try {
         fetch('/api/debug/playback', {
           method: 'POST',
@@ -176,44 +175,8 @@ export default {
         }).catch(() => {})
       } catch (e) {}
       if (url && url !== oldUrl) {
-        const media = this.plyr.media;
-        // If onEnded already loaded this track directly (page was frozen
-        // and the watcher was deferred), skip the reload to avoid
-        // resetting playback back to 0.
-        const currentHash = this.currentPlayingFile && this.currentPlayingFile.hash
-        if (this._directLoadHash && currentHash === this._directLoadHash) {
-          this._directLoadHash = null
-          this._debugLog('watcher_skip_direct_load')
-          return
-        }
-        media.load();
         this._debugLog('source_changed')
-        try {
-          fetch('/api/debug/playback', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ event: 'source_url_diff', oldUrl: (oldUrl||'').slice(0,60), newUrl: (url||'').slice(0,60), ts: Date.now() }),
-            keepalive: true
-          }).catch(() => {})
-        } catch (e) {}
-        this._endedHandled = false;
-        this._stopKeepalive()
-        this.loadLrcFile();
-        this.updateMediaSessionMetadata();
-        if (this.playing) {
-          this._debugLog('source_play_attempt')
-          this.plyr.play().catch((e) => {
-            this._debugLog('source_play_rejected')
-            try {
-              fetch('/api/debug/playback', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ event: 'source_play_error', error: String(e), name: e && e.name, ts: Date.now() }),
-                keepalive: true
-              }).catch(() => {})
-            } catch (err) {}
-          })
-        }
+        this._onSourceChange(url)
       }
     },
 
@@ -416,28 +379,64 @@ export default {
         }).catch(() => {})
       } catch (e) {}
 
-      // Directly load and play the next track synchronously.
+      // Load and play the next track synchronously, inside the event handler.
       // Chrome freezes hidden pages: Vue's nextTick-based `source` watcher
-      // may be deferred for minutes, so the watcher-driven media.load()
-      // happens far too late. Doing it here (inside the event handler)
-      // starts the next track immediately. The watcher will later fire
-      // with the same URL; the marker below makes it skip the reload.
+      // may be deferred for minutes, so the watcher-driven load happens far
+      // too late. When the watcher eventually fires with the same URL,
+      // _loadSource sees the element already has it and skips the reload.
       if (this.playing && this.plyr && this.playMode.name !== "repeat once") {
-        const media = this.plyr.media
         const newUrl = this.source
-        if (media && newUrl) {
-          this._directLoadHash = this.currentPlayingFile && this.currentPlayingFile.hash
-          media.src = newUrl
-          media.load()
-          this._endedHandled = false
-          this.loadLrcFile()
-          this.updateMediaSessionMetadata()
+        if (newUrl) {
           this._debugLog('direct_load')
-          media.play().catch(() => {
-            this._debugLog('direct_load_play_rejected')
-          })
+          this._onSourceChange(newUrl)
           this._startKeepalive()
         }
+      }
+    },
+
+    // Imperatively point the media element at `url` and load it.
+    // Returns true if a new source was actually loaded; false if the element
+    // already has this exact source (and is not in an error state), meaning
+    // no reload is needed.
+    _loadSource (url) {
+      const media = this.plyr && this.plyr.media
+      if (!media) return false
+      if (!url) {
+        media.removeAttribute('src')
+        media.load()
+        return false
+      }
+      const absUrl = new URL(url, window.location.href).href
+      if (media.currentSrc === absUrl && !media.error) {
+        this._debugLog('load_source_skip_same')
+        return false
+      }
+      media.src = url
+      media.load()
+      return true
+    },
+
+    // Shared body for reacting to a source change: load the new track,
+    // reset ended-detection, refresh lyrics/metadata, and start playback.
+    _onSourceChange (url) {
+      if (!this._loadSource(url)) return
+      this._endedHandled = false;
+      this._stopKeepalive()
+      this.loadLrcFile();
+      this.updateMediaSessionMetadata();
+      if (this.playing) {
+        this._debugLog('source_play_attempt')
+        this.plyr.play().catch((e) => {
+          this._debugLog('source_play_rejected')
+          try {
+            fetch('/api/debug/playback', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ event: 'source_play_error', error: String(e), name: e && e.name, ts: Date.now() }),
+              keepalive: true
+            }).catch(() => {})
+          } catch (err) {}
+        })
       }
     },
 
@@ -753,6 +752,7 @@ export default {
     this.initAudioAnalyzer();
     this.createLrcObj();
     if (this.source) {
+      this._loadSource(this.source);
       this.loadLrcFile();
     }
   },

--- a/frontend/src/components/AudioElement.vue
+++ b/frontend/src/components/AudioElement.vue
@@ -98,6 +98,7 @@ export default {
 
       isChangingCurrentTime: false,
       changeCurrentTime: 0,
+      _endedHandled: false,
     }
   },
 
@@ -160,8 +161,15 @@ export default {
       if (url) {
         const media = this.plyr.media;
         media.load();
+        this._endedHandled = false;
         this.loadLrcFile();
         this.updateMediaSessionMetadata();
+        // Explicitly start playback after loading new source.
+        // On Android when locked, 'canplay' may not fire (browser throttles
+        // media loading in hidden pages), so we cannot rely on onCanplay alone.
+        if (this.playing) {
+          this.plyr.play().catch(() => {})
+        }
       }
     },
 
@@ -224,10 +232,12 @@ export default {
     onPause() {
       this.playLrc(false)
       this.PAUSE()
+      try { navigator.mediaSession.playbackState = 'paused' } catch (e) {}
     },
     onPlaying() {
       this.playLrc(true)
       this.PLAY()
+      try { navigator.mediaSession.playbackState = 'playing' } catch (e) {}
     },
     onWaiting() {
       this.playLrc(false)
@@ -265,7 +275,6 @@ export default {
         this.$q.notify({message: "已恢复播放历史", timeout: 1000})
       }
     },
-
     onTimeupdate () {
       this.SET_CURRENT_TIME(this.plyr.currentTime)
       if (this.enablePIPLyrics) this.debouncedPlayLrc(false)
@@ -282,9 +291,19 @@ export default {
           this.$q.sessionStorage.set('sleepMode', false)
         }
       }
+      // Fallback ended detection: on some Android browsers the 'ended' event
+      // does not fire when the phone is locked. Use timeupdate to detect
+      // that we've reached the end of the track.
+      if (!this._endedHandled && this.plyr && this.plyr.duration > 0) {
+        if (this.plyr.currentTime >= this.plyr.duration - 0.5) {
+          this._endedHandled = true;
+          this.onEnded();
+        }
+      }
     },
 
     onEnded () {
+      this._endedHandled = true;
       switch (this.playMode.name) {
         case "all repeat":
           if (this.queueIndex === this.queue.length - 1) {
@@ -398,6 +417,7 @@ export default {
           navigator.mediaSession.setActionHandler('previoustrack', null);
           navigator.mediaSession.setActionHandler('seekbackward', null);
           navigator.mediaSession.setActionHandler('seekforward', null);
+          navigator.mediaSession.playbackState = 'none';
         } else {
           navigator.mediaSession.metadata = new window.MediaMetadata({
             title: this.currentPlayingFile.title,
@@ -442,6 +462,7 @@ export default {
           navigator.mediaSession.setActionHandler('seekforward', () => {
             this.SET_FORWARD_SEEK_MODE(true)
           })
+          navigator.mediaSession.playbackState = this.playing ? 'playing' : 'paused';
         }
       } catch (e) {
         console.warn("set mediasession failed, because: ", e)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3829,7 +3829,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10633,7 +10632,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3829,6 +3829,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10632,6 +10633,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
The next track does not automatically advance when playing on mobile with phone locked.
After investigation, this is largely due to the OS's power saving policy. If chrome has no network access when phone is locked
there is no way to work. But now it should be more stable than before.