### PR TITLE
Use real cover URLs from metadata source, fall back to DLsite path guessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ kikoenai/
 
 ### Container
 
-An OCI container image is built at ()[https://github.com/Rivers47/Kikoenai/pkgs/container/kikoenai]
+An OCI container image is built at [here](https://github.com/Rivers47/Kikoenai/pkgs/container/kikoenai)
 
 Sample rootless quadlet config
 

--- a/backend/filesystem/scannerModules.js
+++ b/backend/filesystem/scannerModules.js
@@ -305,7 +305,10 @@ async function getCoverImageForTranslated(id, types, coverUrls) {
     return getCoverImageFromUrls(id, types, urls);
   }
 
-  // Fall back to the original DLsite path-guessing logic
+  // Fall back to DLsite: for translated works, ask DLsite for the real cover.
+  // Modern translated works live under a <translation-product-slider> that
+  // carries the cover URLs directly (see dlsite.js); older ones are handled
+  // by matching the work_edition_linklist to the original work id.
   let coverFromId = rjcode; // 默认就使用原始的作品id
   let isNoImgMain = false;
   try {
@@ -314,6 +317,10 @@ async function getCoverImageForTranslated(id, types, coverUrls) {
     const tryScrapResult = await scrapeCoverIdForTranslatedWorkFromDLsite(rjcode);
     coverFromId = tryScrapResult.coverFromId;
     isNoImgMain = tryScrapResult.isNoImgMain;
+    if (tryScrapResult.coverUrls && (tryScrapResult.coverUrls.main || tryScrapResult.coverUrls.sam || tryScrapResult.coverUrls['240x240'])) {
+      LOG.task.info(rjcode, `从 DLsite 页面解析到真实封面 URL，直接下载...`);
+      return getCoverImageFromUrls(id, types, tryScrapResult.coverUrls);
+    }
     if (coverFromId != rjcode) {
       LOG.task.info(rjcode, `当前作品RJ${rjcode}似乎不包含封面资源，例如一些翻译作品。从 DLsite 对应的原始作品RJ${coverFromId}下载封面...`);
     }

--- a/backend/filesystem/scannerModules.js
+++ b/backend/filesystem/scannerModules.js
@@ -259,7 +259,19 @@ async function getMetadata(id, rootFolderName, dir) {
   }
 
   LOG.task.info(rjcode, '元数据成功添加到数据库.');
-  return 'added';
+
+  // Covers for DLsite translated (and newer) works are often stored under the
+  // original work id / a proxy address, so the guessed path misses them. When
+  // the metadata source (ASMR.one) returns real cover URLs, expose them as
+  // coverUrls so getCoverImageForTranslated can download them directly.
+  if (metadata && (metadata.mainCoverUrl || metadata.samCoverUrl || metadata.thumbnailCoverUrl)) {
+    metadata.coverUrls = {
+      main: metadata.mainCoverUrl,
+      sam: metadata.samCoverUrl,
+      '240x240': metadata.thumbnailCoverUrl,
+    };
+  }
+  return metadata;
 }
 
 
@@ -269,8 +281,31 @@ async function getMetadata(id, rootFolderName, dir) {
  * @param {number} id work id
  * @param {Array} types img types: ['main', 'sam', 'sam@2x', 'sam@3x', '240x240', '360x360']
  */
-async function getCoverImageForTranslated(id, types) {
+async function getCoverImageForTranslated(id, types, coverUrls) {
   const rjcode = formatID(id); // zero-pad to 6/8 digits
+
+  // Prefer the real cover URLs provided by the metadata source (ASMR.one); this
+  // avoids guessing a DLsite path that 404s for translated/newer works.
+  let urls = coverUrls;
+  if (!urls || !(urls.main || urls.sam || urls['240x240'])) {
+    // During re-scans coverUrls may be missing: try once more to get real cover
+    // URLs from ASMR.one before falling back to path guessing.
+    try {
+      const meta = await scrapeWorkMetadataFromAsmrOne(id);
+      urls = {
+        main: meta.mainCoverUrl,
+        sam: meta.samCoverUrl,
+        '240x240': meta.thumbnailCoverUrl,
+      };
+    } catch (err) {
+      LOG.task.warn(rjcode, `尝试从 ASMR.one 获取真实封面 URL 失败，将回退到 DLsite 路径猜测: ${err.message}`);
+    }
+  }
+  if (urls && (urls.main || urls.sam || urls['240x240'])) {
+    return getCoverImageFromUrls(id, types, urls);
+  }
+
+  // Fall back to the original DLsite path-guessing logic
   let coverFromId = rjcode; // 默认就使用原始的作品id
   let isNoImgMain = false;
   try {
@@ -294,6 +329,35 @@ async function getCoverImageForTranslated(id, types) {
   }
 
   return result;
+}
+
+/**
+ * Download cover images from the real URLs provided by the metadata source
+ * (e.g. ASMR.one's cover proxy), avoiding guessed DLsite paths that 404 for
+ * translated/newer works.
+ * @param {number} cover_for_id work id
+ * @param {Array} types img types: ['main', 'sam', '240x240', ...]
+ * @param {Object} coverUrls map of type -> url (keys: main / sam / 240x240 / ...)
+ * @returns {Promise<String>} 'added' or 'failed'
+ */
+async function getCoverImageFromUrls(cover_for_id, types, coverUrls) {
+  const cover_for_rjcode = formatID(cover_for_id);
+  LOG.task.info(cover_for_rjcode, `从来源 URL 下载封面...`);
+  const results = await Promise.all(types.map(async (type) => {
+    const url = coverUrls[type];
+    if (!url) return 'failed';
+    try {
+      const imageRes = await axios.retryGet(url, { responseType: "stream", retry: {} });
+      await saveCoverImageToDisk(imageRes.data, cover_for_rjcode, type);
+      LOG.task.info(cover_for_rjcode, `封面 ${coverFileName(cover_for_rjcode, type)} 下载成功.`);
+      return 'added';
+    } catch (err) {
+      LOG.task.warn(cover_for_rjcode, `在下载封面 ${coverFileName(cover_for_rjcode, type)} 过程中出错: ${err.message} (URL: ${url})`);
+      return 'failed';
+    }
+  }));
+
+  return results.includes("failed") ? "failed" : "added";
 }
 
 /**
@@ -465,7 +529,7 @@ async function processFolder(folder) {
       // result is the inserted metadata object for Fanza works
       coverResult = await getFanzaCoverImage(workId, coverTypes, result.coverUrls);
     } else {
-      coverResult = await getCoverImageForTranslated(workId, coverTypes);
+      coverResult = await getCoverImageForTranslated(workId, coverTypes, result && result.coverUrls);
     }
   }
 

--- a/backend/filesystem/scannerModules.js
+++ b/backend/filesystem/scannerModules.js
@@ -170,7 +170,8 @@ function uniqueFolderListSeparate(arr) {
 
 /**
  * 从 DLsite 或 Fanza 抓取该音声的元数据，并保存到数据库，
- * 返回一个 Promise 对象，处理结果: 'added' or 'failed'
+ * 返回一个 Promise 对象，处理结果: the inserted metadata object, or 'failed'
+ * (callers need metadata.coverUrls for the cover download)
  * @param {string} id work id (e.g. '123456', 'd_215444')
  * @param {string} rootFolderName 根文件夹别名
  * @param {string} dir 音声文件夹相对路径
@@ -260,10 +261,9 @@ async function getMetadata(id, rootFolderName, dir) {
 
   LOG.task.info(rjcode, '元数据成功添加到数据库.');
 
-  // Covers for DLsite translated (and newer) works are often stored under the
-  // original work id / a proxy address, so the guessed path misses them. When
-  // the metadata source (ASMR.one) returns real cover URLs, expose them as
-  // coverUrls so getCoverImageForTranslated can download them directly.
+  // Only ASMR.one returns cover URLs. Expose them as coverUrls so
+  // getCoverImageForTranslated can use them as a last resort when no DLsite
+  // URL works, without paying for a second ASMR.one request.
   if (metadata && (metadata.mainCoverUrl || metadata.samCoverUrl || metadata.thumbnailCoverUrl)) {
     metadata.coverUrls = {
       main: metadata.mainCoverUrl,
@@ -278,49 +278,30 @@ async function getMetadata(id, rootFolderName, dir) {
 /**
  * 从 DLsite 下载封面图片，处理翻译作品本身没有封面的情况，并保存到 Images 文件夹，
  * 返回一个 Promise 对象，处理结果: 'added' 'failed' 'skipped' return skipped means work do not have cover in dlsite by default
+ *
+ * Each type is tried against DLsite first — the real URL parsed from the work
+ * page, then the guessed path — and only falls back to the ASMR.one cover
+ * proxy when DLsite yields nothing. The guessed path 404s for translated and
+ * newer works, whose covers live under the original work id.
  * @param {number} id work id
  * @param {Array} types img types: ['main', 'sam', 'sam@2x', 'sam@3x', '240x240', '360x360']
+ * @param {Object} [asmrOneCoverUrls] cover urls already known from an ASMR.one metadata scrape
  */
-async function getCoverImageForTranslated(id, types, coverUrls) {
+async function getCoverImageForTranslated(id, types, asmrOneCoverUrls) {
   const rjcode = formatID(id); // zero-pad to 6/8 digits
-
-  // Prefer the real cover URLs provided by the metadata source (ASMR.one); this
-  // avoids guessing a DLsite path that 404s for translated/newer works.
-  let urls = coverUrls;
-  if (!urls || !(urls.main || urls.sam || urls['240x240'])) {
-    // During re-scans coverUrls may be missing: try once more to get real cover
-    // URLs from ASMR.one before falling back to path guessing.
-    try {
-      const meta = await scrapeWorkMetadataFromAsmrOne(id);
-      urls = {
-        main: meta.mainCoverUrl,
-        sam: meta.samCoverUrl,
-        '240x240': meta.thumbnailCoverUrl,
-      };
-    } catch (err) {
-      LOG.task.warn(rjcode, `尝试从 ASMR.one 获取真实封面 URL 失败，将回退到 DLsite 路径猜测: ${err.message}`);
-    }
-  }
-  if (urls && (urls.main || urls.sam || urls['240x240'])) {
-    return getCoverImageFromUrls(id, types, urls);
-  }
-
-  // Fall back to DLsite: for translated works, ask DLsite for the real cover.
-  // Modern translated works live under a <translation-product-slider> that
-  // carries the cover URLs directly (see dlsite.js); older ones are handled
-  // by matching the work_edition_linklist to the original work id.
   let coverFromId = rjcode; // 默认就使用原始的作品id
   let isNoImgMain = false;
+  let realCoverUrls = {};
+
   try {
     // 抓取一次网页，检查当前作品封面到底使用的哪一个id
     // 因为有些翻译作品id自身没有封面文件，而是使用原版日文作品id对应的封面
     const tryScrapResult = await scrapeCoverIdForTranslatedWorkFromDLsite(rjcode);
     coverFromId = tryScrapResult.coverFromId;
     isNoImgMain = tryScrapResult.isNoImgMain;
-    if (tryScrapResult.coverUrls && (tryScrapResult.coverUrls.main || tryScrapResult.coverUrls.sam || tryScrapResult.coverUrls['240x240'])) {
-      LOG.task.info(rjcode, `从 DLsite 页面解析到真实封面 URL，直接下载...`);
-      return getCoverImageFromUrls(id, types, tryScrapResult.coverUrls);
-    }
+    // Modern translated works carry the real cover URLs on a
+    // <translation-product-slider> (see dlsite.js); prefer them over the guess.
+    realCoverUrls = tryScrapResult.coverUrls || {};
     if (coverFromId != rjcode) {
       LOG.task.info(rjcode, `当前作品RJ${rjcode}似乎不包含封面资源，例如一些翻译作品。从 DLsite 对应的原始作品RJ${coverFromId}下载封面...`);
     }
@@ -328,79 +309,101 @@ async function getCoverImageForTranslated(id, types, coverUrls) {
     LOG.task.error(rjcode, `在获取真实的封面id（适配那些翻译作品的封面问题） 过程中出错: ${err.message}`);
   }
 
-  const result = await getCoverImage(id, parseInt(coverFromId), types);
+  LOG.task.info(rjcode, `从 DLsite 下载封面...`);
+  const coverFromIdNumber = parseInt(coverFromId);
+  let failedTypes = await downloadCovers(id, types, (type) => [
+    realCoverUrls[type],
+    guessDLsiteCoverUrl(coverFromIdNumber, type),
+  ]);
 
-  if (result === 'failed' && isNoImgMain) {
+  if (failedTypes.length) {
+    const urls = await getAsmrOneCoverUrls(id, asmrOneCoverUrls);
+    if (urls) {
+      LOG.task.info(rjcode, `DLsite 封面下载失败，尝试从 ASMR.one 下载...`);
+      failedTypes = await downloadCovers(id, failedTypes, (type) => [urls[type]]);
+    }
+  }
+
+  if (!failedTypes.length) {
+    return 'added';
+  }
+
+  if (isNoImgMain) {
     LOG.main.warn(`RJ${rjcode} 作品本身在DlSite上没有封面图片，无法抓取封面`);
     return 'skipped';
   }
 
-  return result;
+  return 'failed';
 }
 
 /**
- * Download cover images from the real URLs provided by the metadata source
- * (e.g. ASMR.one's cover proxy), avoiding guessed DLsite paths that 404 for
- * translated/newer works.
- * @param {number} cover_for_id work id
- * @param {Array} types img types: ['main', 'sam', '240x240', ...]
- * @param {Object} coverUrls map of type -> url (keys: main / sam / 240x240 / ...)
- * @returns {Promise<String>} 'added' or 'failed'
+ * Cover URLs from ASMR.one's cover proxy, reusing the ones a metadata scrape
+ * already returned when available.
+ * @param {number} id work id
+ * @param {Object} [known] map of type -> url from a previous ASMR.one scrape
+ * @returns {Promise<Object|null>} map of type -> url, or null when unavailable
  */
-async function getCoverImageFromUrls(cover_for_id, types, coverUrls) {
-  const cover_for_rjcode = formatID(cover_for_id);
-  LOG.task.info(cover_for_rjcode, `从来源 URL 下载封面...`);
-  const results = await Promise.all(types.map(async (type) => {
-    const url = coverUrls[type];
-    if (!url) return 'failed';
-    try {
-      const imageRes = await axios.retryGet(url, { responseType: "stream", retry: {} });
-      await saveCoverImageToDisk(imageRes.data, cover_for_rjcode, type);
-      LOG.task.info(cover_for_rjcode, `封面 ${coverFileName(cover_for_rjcode, type)} 下载成功.`);
-      return 'added';
-    } catch (err) {
-      LOG.task.warn(cover_for_rjcode, `在下载封面 ${coverFileName(cover_for_rjcode, type)} 过程中出错: ${err.message} (URL: ${url})`);
-      return 'failed';
-    }
-  }));
+async function getAsmrOneCoverUrls(id, known) {
+  if (known && (known.main || known.sam || known['240x240'])) {
+    return known;
+  }
 
-  return results.includes("failed") ? "failed" : "added";
+  try {
+    const meta = await scrapeWorkMetadataFromAsmrOne(id);
+    return {
+      main: meta.mainCoverUrl,
+      sam: meta.samCoverUrl,
+      '240x240': meta.thumbnailCoverUrl,
+    };
+  } catch (err) {
+    LOG.task.warn(formatID(id), `尝试从 ASMR.one 获取封面 URL 失败: ${err.message}`);
+    return null;
+  }
 }
 
 /**
- * 从 DLsite 下载封面图片，并保存到 Images 文件夹，
- * 返回一个 Promise 对象，处理结果: 'added' or 'failed'
- * @param {number} cover_for_id download cover for this work id
+ * DLsite stores covers in a folder named after the work id rounded up to the
+ * next thousand — a guess, since only the work page holds the real URL.
  * @param {number} cover_from_id download cover from work id, since some translated work are using non-translated work's cover resource
- * @param {Array} types img types: ['main', 'sam', 'sam@2x', 'sam@3x', '240x240', '360x360']
+ * @param {String} type img type
+ * @returns {String} guessed cover URL
  */
-async function getCoverImage(cover_for_id, cover_from_id, types) {
-  const cover_for_rjcode = formatID(cover_for_id);
+function guessDLsiteCoverUrl(cover_from_id, type) {
   const rjcode = formatID(cover_from_id); // zero-pad to 6 or 8 digits
   const id2 = (cover_from_id % 1000 === 0) ? cover_from_id : Math.floor(cover_from_id / 1000) * 1000 + 1000;
   const rjcode2 = formatID(id2); // zero-pad to 6 or 8 digits
 
-  LOG.task.info(cover_for_rjcode, `从 DLsite 下载封面...`);
-  const results = await Promise.all(types.map(async (type) => {
-    let url = `https://img.dlsite.jp/modpub/images2/work/doujin/RJ${rjcode2}/RJ${rjcode}_img_${type}.jpg`;
-    if (type === '240x240'|| type === '360x360') {
-      url = `https://img.dlsite.jp/resize/images2/work/doujin/RJ${rjcode2}/RJ${rjcode}_img_main_${type}.jpg`;
-    }
+  return (type === '240x240' || type === '360x360')
+    ? `https://img.dlsite.jp/resize/images2/work/doujin/RJ${rjcode2}/RJ${rjcode}_img_main_${type}.jpg`
+    : `https://img.dlsite.jp/modpub/images2/work/doujin/RJ${rjcode2}/RJ${rjcode}_img_${type}.jpg`;
+}
 
-    try {
-      const imageRes = await axios.retryGet(url, { responseType: "stream", retry: {} });
-      await saveCoverImageToDisk(imageRes.data, cover_for_rjcode, type);
-      LOG.task.info(cover_for_rjcode, `封面 RJ${rjcode}_img_${type}.jpg 下载成功.`);
-      return 'added';
-    } catch(err) {
-      LOG.task.warn(cover_for_rjcode, `在下载封面 RJ${rjcode}_img_${type}.jpg 过程中出错: ${err.message} (URL: ${url})`);
-      return 'failed';
+/**
+ * Download one cover image per type, saving it to the Images 文件夹. Each
+ * type falls through its candidate URLs until one downloads, so a source that
+ * only knows some of the types does not defeat the others.
+ * @param {number} cover_for_id download cover for this work id
+ * @param {Array} types img types: ['main', 'sam', 'sam@2x', 'sam@3x', '240x240', '360x360']
+ * @param {Function} candidatesFor type => candidate URLs, tried in order (falsy entries skipped)
+ * @returns {Promise<Array>} the types that could not be downloaded
+ */
+async function downloadCovers(cover_for_id, types, candidatesFor) {
+  const cover_for_rjcode = formatID(cover_for_id);
+  const results = await Promise.all(types.map(async (type) => {
+    for (const url of candidatesFor(type).filter(Boolean)) {
+      try {
+        const imageRes = await axios.retryGet(url, { responseType: "stream", retry: {} });
+        await saveCoverImageToDisk(imageRes.data, cover_for_rjcode, type);
+        LOG.task.info(cover_for_rjcode, `封面 ${coverFileName(cover_for_rjcode, type)} 下载成功.`);
+        return null;
+      } catch (err) {
+        LOG.task.warn(cover_for_rjcode, `在下载封面 ${coverFileName(cover_for_rjcode, type)} 过程中出错: ${err.message} (URL: ${url})`);
+      }
     }
+    return type;
   }));
 
-  return results.includes("failed") 
-      ? "failed" 
-      : "added";
+  return results.filter(Boolean);
 }
 
 /**

--- a/backend/scraper/dlsite.js
+++ b/backend/scraper/dlsite.js
@@ -367,9 +367,38 @@ const scrapeCoverIdForTranslatedWorkFromDLsite = (id_translated) => new Promise(
 
       const hit_id_list = linked_id_list.filter(id => possible_image_id_list.includes(id));
 
+      // New-style pages replace the work_edition_linklist markup with a
+      // <translation-product-slider> component that carries the real cover
+      // URLs directly (under the original work id). When present, expose them
+      // so the caller can download without guessing paths.
+      let realCoverUrls = {};
+      const slider = $('translation-product-slider').first();
+      if (slider.length) {
+        const sliderSrc = slider.attr('src') || '';
+        const sliderThumb = slider.attr('thumb') || '';
+        const toHttp = u => u.replace(/^\/\//, 'https://');
+        if (sliderSrc) {
+          const mainUrl = toHttp(sliderSrc);
+          realCoverUrls.main = mainUrl;
+          const samUrl = mainUrl.replace(/_img_main\.(jpg|png|webp)/i, '_img_sam.$1');
+          if (samUrl !== mainUrl) realCoverUrls.sam = samUrl;
+          if (sliderThumb) realCoverUrls['240x240'] = toHttp(sliderThumb);
+        }
+        // If the cover belongs to the original (Japanese) work, prefer its id
+        // for the guessed-path fallback in getCoverImage.
+        const mainUrlMatch = realCoverUrls.main && /RJ(\d{6,8})[_\w.]+$/.exec(new URL(realCoverUrls.main).pathname);
+        if (mainUrlMatch) {
+          const realCoverFromId = mainUrlMatch[1];
+          if (realCoverFromId !== String(id_translated) && !hit_id_list.includes(realCoverFromId)) {
+            hit_id_list.unshift(realCoverFromId);
+          }
+        }
+      }
+
       const result = {
         coverFromId: hit_id_list.length > 0 ? hit_id_list[0] : id_translated,
         isNoImgMain,
+        coverUrls: Object.keys(realCoverUrls).length > 0 ? realCoverUrls : undefined,
       };
       resolve(result);
     })

--- a/backend/scraper/dlsite.js
+++ b/backend/scraper/dlsite.js
@@ -371,26 +371,42 @@ const scrapeCoverIdForTranslatedWorkFromDLsite = (id_translated) => new Promise(
       // <translation-product-slider> component that carries the real cover
       // URLs directly (under the original work id). When present, expose them
       // so the caller can download without guessing paths.
-      let realCoverUrls = {};
+      const realCoverUrls = {};
       const slider = $('translation-product-slider').first();
       if (slider.length) {
         const sliderSrc = slider.attr('src') || '';
         const sliderThumb = slider.attr('thumb') || '';
-        const toHttp = u => u.replace(/^\/\//, 'https://');
-        if (sliderSrc) {
-          const mainUrl = toHttp(sliderSrc);
+        // src/thumb may be protocol-relative or root-relative; resolve against
+        // the work page so a malformed value can't throw out of the scrape.
+        // Anything that doesn't resolve to an image path is not a cover — a
+        // placeholder like "#" would otherwise resolve to the page itself.
+        const toAbsolute = (u) => {
+          try {
+            const resolved = new URL(u, url);
+            return /\.(jpe?g|png|webp|gif)$/i.test(resolved.pathname) ? resolved.href : '';
+          } catch {
+            return '';
+          }
+        };
+        const mainUrl = sliderSrc && toAbsolute(sliderSrc);
+        if (mainUrl) {
           realCoverUrls.main = mainUrl;
-          const samUrl = mainUrl.replace(/_img_main\.(jpg|png|webp)/i, '_img_sam.$1');
+          // DLsite names the variants by suffix, whatever the extension is.
+          const samUrl = mainUrl.replace('_img_main', '_img_sam');
           if (samUrl !== mainUrl) realCoverUrls.sam = samUrl;
-          if (sliderThumb) realCoverUrls['240x240'] = toHttp(sliderThumb);
-        }
-        // If the cover belongs to the original (Japanese) work, prefer its id
-        // for the guessed-path fallback in getCoverImage.
-        const mainUrlMatch = realCoverUrls.main && /RJ(\d{6,8})[_\w.]+$/.exec(new URL(realCoverUrls.main).pathname);
-        if (mainUrlMatch) {
-          const realCoverFromId = mainUrlMatch[1];
-          if (realCoverFromId !== String(id_translated) && !hit_id_list.includes(realCoverFromId)) {
-            hit_id_list.unshift(realCoverFromId);
+          if (sliderThumb) {
+            const thumbUrl = toAbsolute(sliderThumb);
+            if (thumbUrl) realCoverUrls['240x240'] = thumbUrl;
+          }
+
+          // The cover usually belongs to the original (Japanese) work; prefer
+          // its id for the guessed-path fallback in guessDLsiteCoverUrl.
+          const mainUrlMatch = /RJ(\d{6,8})[_\w.]+$/.exec(new URL(mainUrl).pathname);
+          if (mainUrlMatch) {
+            const realCoverFromId = mainUrlMatch[1];
+            if (realCoverFromId !== rjcode && !hit_id_list.includes(realCoverFromId)) {
+              hit_id_list.unshift(realCoverFromId);
+            }
           }
         }
       }


### PR DESCRIPTION
I've met the problem that scanning fails for many works I added — covers download get 404. Kikoenai guesses DLsite image URLs by rounding the work id to the next thousand, and that guessed path no longer exists for translated works (whose covers live under the original work) and newer works.

Fix: download covers from the real URLs returned by the metadata source (ASMR.one's main/sam/thumbnail cover proxy). If none is available, re-fetch it from ASMR.one once; only fall back to the original DLsite path guessing as a last resort.

Tested on my instance, the scan failures dropped from 185 to 0.
